### PR TITLE
Avoid infinite loop in a special case

### DIFF
--- a/yamdi.c
+++ b/yamdi.c
@@ -2063,8 +2063,10 @@ unsigned int readCodedUE(bitstream_t *bitstream, const char *name) {
 	int bit;
 	unsigned int codeNum = 0;
 
-	for(bit = 0; bit == 0; leadingZeroBits++)
+	for(bit = 0; bit == 0; leadingZeroBits++) {
 		bit = readBit(bitstream);
+		if (bitstream->byte == bitstream->length) break;
+	}
 
 	codeNum = ((1 << leadingZeroBits) - 1 + (unsigned int)readBits(bitstream, leadingZeroBits));
 


### PR DESCRIPTION
This patch fixes a bug in yamdi.c, when calling readBit with a bitstream, where bitstream->byte == bitstream->length. It always returns 0 in this case and will cause an infinite loop in readCodedUE.
