### PR TITLE
Enable including original scriptdata tags in the output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 yamdi
+/build/
 /samples/
 *.flv
 *.exe
 *.xml
+*.deb

--- a/fpm.sh
+++ b/fpm.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [ -z $1 ] 
+  then 
+    echo "Usage: <version> [vendor] [maintainer] [url]";
+    exit 1; 
+fi
+
+rm -rf build/
+
+mkdir -p build/{deb,bin}
+mkdir -p build/share/{doc/yamdi,man/man1}
+
+make clean
+make yamdi
+
+cp yamdi build/bin/
+cp {README,LICENSE,CHANGES} build/share/doc/yamdi/
+gzip -cf man1/yamdi.1 > build/share/man/man1/yamdi1.gz
+
+rm -f yamdi_*.deb
+fpm -t deb -s dir -C build -n yamdi -v $1 -a all --prefix /usr --depends 'libc6 (>= 2.4)' \
+  --vendor "$2" --maintainer "$3" --url "$4" \
+  bin/ share/

--- a/man1/yamdi.1
+++ b/man1/yamdi.1
@@ -49,6 +49,9 @@ Add the onLastKeyframe event.
 .B \-M
 Strip all metadata from the FLV. The -s and -k options will be ignored.
 .TP
+.B \-m
+Leave the existing metadata intact. Metadata that yamdi does not add is left untouched, e.g. onCuepoint, onCaptionInfo.
+.TP
 .B \-X
 Omit the keyframes tag in the XML output.
 .TP

--- a/yamdi.c
+++ b/yamdi.c
@@ -185,7 +185,7 @@ typedef struct {
 		short addonmetadata;		// defaults to 1, -M does change it
 		short addaudiokeyframes;	// -a
 
-		short keepmetadata;		// -m (not implemented)
+		short keepmetadata;		// -m
 		short stripmetadata;		// -M
 
 		short xmlomitkeyframes;		// -X
@@ -302,7 +302,7 @@ int main(int argc, char **argv) {
 
 	initFLV(&flv);
 
-	while((c = getopt(argc, argv, ":i:o:x:t:c:a:lskMXwh")) != -1) {
+	while((c = getopt(argc, argv, ":i:o:x:t:c:a:lskMXwhm")) != -1) {
 		switch(c) {
 			case 'i':
 				infile = optarg;
@@ -334,11 +334,9 @@ int main(int argc, char **argv) {
 					flv.options.addaudiokeyframes = 0;
 				}
 				break;
-/*
 			case 'm':
 				flv.options.keepmetadata = 1;
 				break;
-*/
 			case 'M':
 				flv.options.stripmetadata = 1;
 				break;
@@ -988,7 +986,9 @@ int finalizeFLV(FLV_t *flv, FILE *fp) {
 		flvtag = &flv->index.flvtag[i];
 
 		// Skip every script tag (subject to change if we want to keep existing events)
-		if(flvtag->tagtype != FLV_TAG_AUDIO && flvtag->tagtype != FLV_TAG_VIDEO)
+		if(flvtag->tagtype != FLV_TAG_AUDIO && flvtag->tagtype != FLV_TAG_VIDEO && flvtag->tagtype != FLV_TAG_SCRIPTDATA)
+			continue;
+		if(flvtag->tagtype == FLV_TAG_SCRIPTDATA && flv->options.keepmetadata != 1)
 			continue;
 
 		// Take care of the onlastsecond event
@@ -1054,7 +1054,10 @@ int writeFLV(FILE *out, FLV_t *flv, FILE *fp) {
 		flvtag = &flv->index.flvtag[i];
 
 		// Skip every script tag (subject to change if we want to keep existing events)
-		if(flvtag->tagtype != FLV_TAG_AUDIO && flvtag->tagtype != FLV_TAG_VIDEO)
+		if(flvtag->tagtype != FLV_TAG_AUDIO && flvtag->tagtype != FLV_TAG_VIDEO && flvtag->tagtype != FLV_TAG_SCRIPTDATA)
+			continue;
+
+		if(flvtag->tagtype == FLV_TAG_SCRIPTDATA && flv->options.keepmetadata != 1)
 			continue;
 
 		// Write the onlastsecond event
@@ -2360,11 +2363,9 @@ void printUsage(void) {
 	fprintf(stderr, "\n");
 	fprintf(stderr, "\t-k\tAdd the onLastKeyframe event.\n");
 	fprintf(stderr, "\n");
-/*
 	fprintf(stderr, "\t-m\tLeave the existing metadata intact.\n");
-	fprintf(stderr, "\t\tMetadata that yamdi does not add is left untouched, e.g. onCuepoint.\n");
+	fprintf(stderr, "\t\tMetadata that yamdi does not add is left untouched, e.g. onCuepoint, onCaptionInfo.\n");
 	fprintf(stderr, "\n");
-*/
 	fprintf(stderr, "\t-M\tStrip all metadata from the FLV. The -s and -k options will\n");
 	fprintf(stderr, "\t\tbe ignored.\n");
 	fprintf(stderr, "\n");


### PR DESCRIPTION
Enabled the keepmetadata option, to include scriptdata tags in the output
